### PR TITLE
feat: add sign-in page UI with form and styling

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Toaster } from "sonner";
+import { ThemeProvider } from "@/components/theme-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +29,15 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+          >
+         <Toaster />
+          {children}
+          </ThemeProvider>
       </body>
     </html>
   );

--- a/app/sign-in/SigninForm.tsx
+++ b/app/sign-in/SigninForm.tsx
@@ -1,0 +1,108 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+"use client"
+
+import { useState } from "react"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { GithubIcon } from "lucide-react"
+import { authClient } from "../lib/auth-client"
+
+export function SigninForm() {
+  const router = useRouter()
+
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  async function handleSignin(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+
+    await authClient.signIn.email(
+      {
+        email,
+        password,
+        callbackURL: "/dashboard/lab",
+      },
+      {
+        onRequest: () => setLoading(true),
+        onSuccess: () => {
+          toast.success("Signed in successfully!")
+          router.push("/dashboard/lab")
+        },
+        onError: (ctx) => {
+          toast.error(ctx.error.message || "Invalid credentials")
+          setLoading(false)
+        },
+      }
+    )
+
+    setLoading(false)
+  }
+
+  async function handleGithubSignin() {
+    try {
+      await authClient.signIn.social({
+        provider: "github",
+        callbackURL: "/dashboard/lab",
+      })
+    } catch (err) {
+      toast.error("GitHub sign-in failed")
+    }
+  }
+
+  return (
+    <div className="max-w-md w-full mx-auto p-6 border border-border rounded-2xl shadow-md bg-white dark:bg-zinc-900 space-y-6">
+      {/* Header */}
+      <div className="text-center space-y-1">
+        <h1 className="text-2xl font-bold">Welcome back to SuperEnvoy</h1>
+        <p className="text-sm text-muted-foreground">Sign in to continue building your AI</p>
+      </div>
+
+      <form onSubmit={handleSignin} className="space-y-5">
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+
+        <Button type="submit" disabled={loading} className="w-full">
+          {loading ? "Signing in..." : "Sign In"}
+        </Button>
+      </form>
+
+      <div className="relative py-2">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t border-muted" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-background px-2 text-muted-foreground">or continue with</span>
+        </div>
+      </div>
+
+      <Button variant="outline" onClick={handleGithubSignin} className="w-full">
+        <GithubIcon className="mr-2 h-4 w-4" /> Continue with GitHub
+      </Button>
+    </div>
+  )
+}

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+
+
+import AuthNavbar from "@/components/AuthNavBar";
+import { SigninForm } from "./SigninForm";
+
+export default function LoginPage() {
+  return (
+    <><AuthNavbar />
+      <main className="min-h-screen flex items-center justify-center p-4"><SigninForm /></main>
+    </>
+  );
+}

--- a/app/sign-up/SignUpForm.tsx
+++ b/app/sign-up/SignUpForm.tsx
@@ -1,0 +1,140 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+"use client"
+
+import { useState } from "react"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { authClient } from "../lib/auth-client"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { Github } from "lucide-react"
+
+export function SignupForm() {
+  const router = useRouter()
+
+  const [email, setEmail] = useState("")
+  const [name, setName] = useState("")
+  const [password, setPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  async function handleSignup(e: React.FormEvent) {
+    e.preventDefault()
+
+    if (password !== confirmPassword) {
+      toast.error("Passwords do not match")
+      return
+    }
+
+    setLoading(true)
+
+    await authClient.signUp.email(
+      {
+        email,
+        password,
+        name,
+        image: undefined,
+        callbackURL: "/dashboard/lab",
+      },
+      {
+        onRequest: () => setLoading(true),
+        onSuccess: () => {
+          toast.success("Account created! Redirecting to dashboard...")
+          router.push("/dashboard/lab")
+        },
+        onError: (ctx) => {
+          toast.error(ctx.error.message || "Something went wrong")
+          setLoading(false)
+        },
+      }
+    )
+
+    setLoading(false)
+  }
+
+  async function handleGithubSignup() {
+    try {
+      await authClient.signIn.social({
+        provider: "github",
+        callbackURL: "/dashboard/lab"
+      })
+    } catch (err) {
+      toast.error("GitHub sign-in failed")
+    }
+  }
+
+  return (
+    <div className="max-w-md w-full mx-auto p-6 border border-border rounded-2xl shadow-md bg-white dark:bg-zinc-900 space-y-6 mt-15">
+      {/* Header */}
+      <div className="text-center space-y-1">
+        {/* <Logo /> */}
+        <h1 className="text-2xl font-bold">Create your SuperEnvoy account</h1>
+        <p className="text-sm text-muted-foreground">Start building your personal AI today</p>
+      </div>
+
+      <form onSubmit={handleSignup} className="space-y-5">
+        <div className="space-y-2">
+          <Label htmlFor="name">Name</Label>
+          <Input
+            id="name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="confirm-password">Confirm Password</Label>
+          <Input
+            id="confirm-password"
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+          />
+        </div>
+
+        <Button type="submit" disabled={loading} className="w-full">
+          {loading ? "Creating account..." : "Sign Up"}
+        </Button>
+      </form>
+
+      <div className="relative py-2">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t border-muted" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-background px-2 text-muted-foreground">or continue with</span>
+        </div>
+      </div>
+
+      <Button variant="outline" onClick={handleGithubSignup} className="w-full">
+        <Github className="mr-2 h-4 w-4" /> Continue with GitHub
+      </Button>
+    </div>
+  )
+}

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -1,0 +1,13 @@
+import AuthNavbar from "@/components/AuthNavBar";
+import { SignupForm } from "./SignUpForm";
+
+
+export default function SignupPage() {
+    return (
+        <>
+            <AuthNavbar />
+            <main className="min-h-screen flex items-center justify-center p-4">
+            <SignupForm />
+        </main></>
+  )
+}

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client"
+ 
+import * as React from "react"
+import { ThemeProvider as NextThemesProvider } from "next-themes"
+ 
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: "class",
+  content: [
+    "./pages/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./app/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}",
+  ],
+};
+
+export default config;


### PR DESCRIPTION
This PR introduces user authentication UI and dark mode

* 🔐 **Sign-in page** with form fields and styled layout
* 🆕 **Sign-up page** with input fields and button
* 🌙 **Dark mode** activated using `next-themes` and `shadcn`, supports system preference and manual toggle

